### PR TITLE
Fix calendar overflow to keep full calendar visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -461,6 +461,8 @@ body {
   display: flex;
   justify-content: center;
   margin-bottom: 16px;
+  /* allow horizontal scrolling so the entire calendar is always accessible */
+  overflow-x: auto;
 }
 .calendar {
   background: #181a1f;
@@ -468,6 +470,9 @@ body {
   box-shadow: 0 2px 8px #0003;
   padding: 12px 18px 18px 18px;
   min-width: 320px;
+  /* keep width constrained to its content and fit smaller viewports */
+  width: fit-content;
+  max-width: 100%;
 }
 .calendar-header {
   text-align: center;


### PR DESCRIPTION
## Summary
- allow horizontal scrolling and constrain calendar width so the full calendar stays visible

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6344cb8e88324bd2226b8f10b70f8