### PR TITLE
Expand schedule grid to 24h with 15-minute blocks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -276,8 +276,8 @@ body {
   min-width: 1200px;
   width: 100%;
   max-width: none;
-  height: calc(24px * 16);
-  min-height: calc(24px * 16);
+  height: calc(24px * 96);
+  min-height: calc(24px * 96);
   align-items: stretch;
   background: #14161a;
   border-radius: 12px;

--- a/js/main.js
+++ b/js/main.js
@@ -36,56 +36,58 @@ function generateGrid() {
   const schedule = schedules[dateStr] || [];
   currentDateSpan.textContent = currentDate.toDateString();
   timeGrid.innerHTML = '';
-  for (let h = 6; h < 22; h++) {
-    const time = `${String(h).padStart(2, '0')}:00`;
-    const row = document.createElement('div');
-    row.className = 'grid-row';
-    const timeCell = document.createElement('div');
-    timeCell.className = 'grid-time';
-    timeCell.textContent = time;
-    const block = document.createElement('div');
-    block.className = 'grid-block';
-    const task = schedule.find(t => t.time === time);
-    if (task) {
-      block.classList.add('task');
-      block.textContent = task.task;
-      block.style.background = categories[task.category] || '#999';
-      block.addEventListener('click', () => {
-        const name = prompt('Edit task or leave empty to delete', task.task);
-        if (name === null) return;
-        const trimmed = name.trim();
-        if (trimmed) {
-          task.task = trimmed;
-        } else {
-          const idx = schedule.indexOf(task);
-          if (idx !== -1) schedule.splice(idx, 1);
-        }
-        schedules[dateStr] = schedule;
-        saveSchedules(schedules);
-        generateGrid();
-        generateMultiDayGrid();
-      });
-    } else {
-      block.classList.add('add-task');
-      block.textContent = '+';
-      block.addEventListener('click', () => {
-        const name = prompt('Task name');
-        if (name === null) return;
-        const trimmed = name.trim();
-        if (!trimmed) return;
-        const cat = prompt('Category', Object.keys(categories)[0] || '');
-        if (cat === null) return;
-        schedule.push({ time, task: trimmed, category: cat });
-        schedules[dateStr] = schedule;
-        saveSchedules(schedules);
-        generateGrid();
-        generateMultiDayGrid();
-      });
-    }
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += 15) {
+      const time = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+      const row = document.createElement('div');
+      row.className = 'grid-row';
+      const timeCell = document.createElement('div');
+      timeCell.className = 'grid-time';
+      timeCell.textContent = time;
+      const block = document.createElement('div');
+      block.className = 'grid-block';
+      const task = schedule.find(t => t.time === time);
+      if (task) {
+        block.classList.add('task');
+        block.textContent = task.task;
+        block.style.background = categories[task.category] || '#999';
+        block.addEventListener('click', () => {
+          const name = prompt('Edit task or leave empty to delete', task.task);
+          if (name === null) return;
+          const trimmed = name.trim();
+          if (trimmed) {
+            task.task = trimmed;
+          } else {
+            const idx = schedule.indexOf(task);
+            if (idx !== -1) schedule.splice(idx, 1);
+          }
+          schedules[dateStr] = schedule;
+          saveSchedules(schedules);
+          generateGrid();
+          generateMultiDayGrid();
+        });
+      } else {
+        block.classList.add('add-task');
+        block.textContent = '+';
+        block.addEventListener('click', () => {
+          const name = prompt('Task name');
+          if (name === null) return;
+          const trimmed = name.trim();
+          if (!trimmed) return;
+          const cat = prompt('Category', Object.keys(categories)[0] || '');
+          if (cat === null) return;
+          schedule.push({ time, task: trimmed, category: cat });
+          schedules[dateStr] = schedule;
+          saveSchedules(schedules);
+          generateGrid();
+          generateMultiDayGrid();
+        });
+      }
 
-    row.appendChild(timeCell);
-    row.appendChild(block);
-    timeGrid.appendChild(row);
+      row.appendChild(timeCell);
+      row.appendChild(block);
+      timeGrid.appendChild(row);
+    }
   }
   renderReport(schedule);
 }
@@ -108,55 +110,57 @@ function generateMultiDayGrid() {
     label.textContent = day.toDateString();
     col.appendChild(label);
 
-    for (let h = 6; h < 22; h++) {
-      const time = `${String(h).padStart(2, '0')}:00`;
-      const row = document.createElement('div');
-      row.className = 'grid-row';
-      const timeCell = document.createElement('div');
-      timeCell.className = 'grid-time';
-      timeCell.textContent = time;
-      const block = document.createElement('div');
-      block.className = 'grid-block';
-      const task = schedule.find(t => t.time === time);
-      if (task) {
-        block.classList.add('task');
-        block.textContent = task.task;
-        block.style.background = categories[task.category] || '#999';
-        block.addEventListener('click', () => {
-          const name = prompt('Edit task or leave empty to delete', task.task);
-          if (name === null) return;
-          const trimmed = name.trim();
-          if (trimmed) {
-            task.task = trimmed;
-          } else {
-            const idx = schedule.indexOf(task);
-            if (idx !== -1) schedule.splice(idx,1);
-          }
-          schedules[dateStr] = schedule;
-          saveSchedules(schedules);
-          generateGrid();
-          generateMultiDayGrid();
-        });
-      } else {
-        block.classList.add('add-task');
-        block.textContent = '+';
-        block.addEventListener('click', () => {
-          const name = prompt('Task name');
-          if (name === null) return;
-          const trimmed = name.trim();
-          if (!trimmed) return;
-          const cat = prompt('Category', Object.keys(categories)[0] || '');
-          if (cat === null) return;
-          schedule.push({time, task:trimmed, category:cat});
-          schedules[dateStr] = schedule;
-          saveSchedules(schedules);
-          generateGrid();
-          generateMultiDayGrid();
-        });
+    for (let h = 0; h < 24; h++) {
+      for (let m = 0; m < 60; m += 15) {
+        const time = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+        const row = document.createElement('div');
+        row.className = 'grid-row';
+        const timeCell = document.createElement('div');
+        timeCell.className = 'grid-time';
+        timeCell.textContent = time;
+        const block = document.createElement('div');
+        block.className = 'grid-block';
+        const task = schedule.find(t => t.time === time);
+        if (task) {
+          block.classList.add('task');
+          block.textContent = task.task;
+          block.style.background = categories[task.category] || '#999';
+          block.addEventListener('click', () => {
+            const name = prompt('Edit task or leave empty to delete', task.task);
+            if (name === null) return;
+            const trimmed = name.trim();
+            if (trimmed) {
+              task.task = trimmed;
+            } else {
+              const idx = schedule.indexOf(task);
+              if (idx !== -1) schedule.splice(idx,1);
+            }
+            schedules[dateStr] = schedule;
+            saveSchedules(schedules);
+            generateGrid();
+            generateMultiDayGrid();
+          });
+        } else {
+          block.classList.add('add-task');
+          block.textContent = '+';
+          block.addEventListener('click', () => {
+            const name = prompt('Task name');
+            if (name === null) return;
+            const trimmed = name.trim();
+            if (!trimmed) return;
+            const cat = prompt('Category', Object.keys(categories)[0] || '');
+            if (cat === null) return;
+            schedule.push({time, task:trimmed, category:cat});
+            schedules[dateStr] = schedule;
+            saveSchedules(schedules);
+            generateGrid();
+            generateMultiDayGrid();
+          });
+        }
+        row.appendChild(timeCell);
+        row.appendChild(block);
+        col.appendChild(row);
       }
-      row.appendChild(timeCell);
-      row.appendChild(block);
-      col.appendChild(row);
     }
     multiDayGrid.appendChild(col);
   }


### PR DESCRIPTION
## Summary
- Expand daily grid and multi-day view to show 15-minute intervals across all 24 hours
- Adjust multi-day grid styling to accommodate extended timeline

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9230830e083248c061ba78c1ce716